### PR TITLE
Require coverage to improve when running CI

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
   "continuous-integration/travis-ci/push",
 #  "continuous-integration/appveyor/branch",
-#  "codecov/patch",
-#  "codecov/project",
+  "codecov/patch",
+  "codecov/project",
 ]
 


### PR DESCRIPTION
This is going to need to wait until we are actually sending coverage.