### PR TITLE
changed pixel_size_arcsec to pixel_size and kernel to address name error

### DIFF
--- a/src/koala/__init__.py
+++ b/src/koala/__init__.py
@@ -10098,8 +10098,8 @@ class KOALA_reduce(RSS, Interpolated_cube):  # TASK_KOALA_reduce
         extra_w=1.3,
         step_csr=25,
         # CUBING
-        pixel_size_arcsec=0.4,
-        kernel_size_arcsec=1.2,
+        pixel_size=0.4,  #removed _arcsec to address name errors
+        kernel_size=1.2,  #removed _arcsec to address name errors
         offsets=[1000],
         ADR=False,
         flux_calibration=[0],


### PR DESCRIPTION
variable names were updated to address name errors as temporary fix for conversion to python3. Suggest adding _arsec back at a later date throughout the file to better characterise the variable