### PR TITLE
Remove python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ cache:
 
 matrix:
   include:
-    - python: 2.7
-      env:
-      - TOXENV=py27 MPLBACKEND=agg
     - python: 3.6
       env:
       - TOXENV=py36 MPLBACKEND=agg

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py35,py36,py37,py38,flake8,pylint,docs,doctest,check-manifest,checkreadme
+envlist = py35,py36,py37,py38,flake8,pylint,docs,doctest,check-manifest,checkreadme
 
 [testenv]
 commands = py.test --cov={envsitepackagesdir}/koala -s {posargs}
@@ -12,12 +12,7 @@ passenv =
     PYTHONFAULTHANDLER
     MPLBACKEND
 deps =-rtest-requirements.txt
-    py27: astropy==2.0.16
-    py27: matplotlib==2.2.3
-    py27: numpy==1.16.6
-    py27: scipy==1.2.3
 basepython =
-    py27: {env:TOXPYTHON:python2.7}
     py35: {env:TOXPYTHON:python3.5}
     py36: {env:TOXPYTHON:python3.6}
     py37: {env:TOXPYTHON:python3.7}


### PR DESCRIPTION
Python 2.7 support dropped

@aragilar I'm not sure if there is other code that needs to be removed to remove the tests/test environments. I am still working on removing old_div #123 