### PR TITLE
create HistoryLog class to store DR history

### DIFF
--- a/src/pykoala/corrections/astrometry.py
+++ b/src/pykoala/corrections/astrometry.py
@@ -148,8 +148,9 @@ class AstrometryCorrection(CorrectionBase):
             data_container.info['fib_ra'] += offset[0].to('deg').value
             data_container.info['fib_dec'] += offset[1].to('deg').value
 
-            self.log_correction(data_container, status='applied',
-                                offset=f"{offset[0].to('arcsec')}{offset[1].to('arcsec')}")
+            self.log_correction(
+                data_container, status='applied',
+                offset=f"{offset[0].to('arcsec')}{offset[1].to('arcsec')} arcsec")
         elif data_container.__class__ is Cube:
             pass
 

--- a/src/pykoala/corrections/correction.py
+++ b/src/pykoala/corrections/correction.py
@@ -37,7 +37,7 @@ class CorrectionBase(ABC):
         if self.verbose:
             print("[Correction: {}] {}".format(self.name, msg), *args)
 
-    def log_correction(self, datacontainer, status='applied', **extra_kwargs):
+    def log_correction(self, datacontainer, status='applied', **extra_comments):
         """Log in the DataContainer the correction and additional info.
         
         Description
@@ -58,8 +58,8 @@ class CorrectionBase(ABC):
         if status != 'applied' and status != 'failed':
             raise KeyError("Correction log status can only be 'applied' or 'failed'")
         
-        datacontainer.log[self.name] = {'status': status}
-        for key, desc in extra_kwargs.items():
-            datacontainer.log[self.name][key] = desc
+        datacontainer.log(self.name, status, tag='correction')
+        for k, v in extra_comments.items():
+            datacontainer.log(self.name, k + " " + str(v), tag='correction')
 
         

--- a/src/pykoala/corrections/correction.py
+++ b/src/pykoala/corrections/correction.py
@@ -59,7 +59,7 @@ class CorrectionBase(ABC):
             raise KeyError("Correction log status can only be 'applied' or 'failed'")
         
         datacontainer.log(self.name, status, tag='correction')
-        for k, v in extra_comments.items():
+        for (k, v) in extra_comments.items():
             datacontainer.log(self.name, k + " " + str(v), tag='correction')
 
         

--- a/src/pykoala/cubing.py
+++ b/src/pykoala/cubing.py
@@ -410,7 +410,7 @@ class Cube(DataContainer):
 
         super(Cube, self).__init__(intensity=self.intensity,
                                    variance=self.variance,
-                                   info=info, **kwargs)
+                                   info=info, log=log, **kwargs)
         self.n_wavelength, self.n_rows, self.n_cols = self.intensity.shape
         self.get_wavelength()
 
@@ -435,12 +435,10 @@ class Cube(DataContainer):
     def parse_info_from_header(self):
         """Look into the primary header for pykoala information."""
         print("[Cube] Looking for information in the primary header")
-        self.info = {}
-        self.log = {'corrections': {}}
-        self.fill_info()
-        print("NOT IMPLEMENTED")
         # TODO
-        pass
+        self.info = {}
+        self.fill_info()
+        self.log.load_from_header(self.hdul[0])
 
     def load_hdul(self, path_to_file):
         print(f"[Cube] Loading HDUL {path_to_file}")

--- a/src/pykoala/cubing.py
+++ b/src/pykoala/cubing.py
@@ -392,8 +392,6 @@ class Cube(DataContainer):
     y_size_arcsec = None
 
     def __init__(self, hdul=None, file_path=None, 
-                 info=None,
-                 log=None,
                  hdul_extensions_map=None, **kwargs):
 
         if hdul is not None:
@@ -408,7 +406,7 @@ class Cube(DataContainer):
         self.get_wcs_from_header()
         super().__init__(intensity=self.intensity,
                          variance=self.variance,
-                         info=info, log=log, **kwargs)
+                         **kwargs)
         self.parse_info_from_header()
         self.n_wavelength, self.n_rows, self.n_cols = self.intensity.shape
         self.get_wavelength()

--- a/src/pykoala/cubing.py
+++ b/src/pykoala/cubing.py
@@ -403,14 +403,13 @@ class Cube(DataContainer):
                 self.hdul_extensions_map = hdul
             print("[Cube] Initialising cube with input HDUL")
             self.hdul = hdul
-            self.parse_info_from_header()
         elif file_path is not None:
             self.load_hdul(file_path)
         self.get_wcs_from_header()
-
-        super(Cube, self).__init__(intensity=self.intensity,
-                                   variance=self.variance,
-                                   info=info, log=log, **kwargs)
+        super().__init__(intensity=self.intensity,
+                         variance=self.variance,
+                         info=info, log=log, **kwargs)
+        self.parse_info_from_header()
         self.n_wavelength, self.n_rows, self.n_cols = self.intensity.shape
         self.get_wavelength()
 
@@ -436,9 +435,9 @@ class Cube(DataContainer):
         """Look into the primary header for pykoala information."""
         print("[Cube] Looking for information in the primary header")
         # TODO
-        self.info = {}
-        self.fill_info()
-        self.log.load_from_header(self.hdul[0])
+        #self.info = {}
+        #self.fill_info()
+        self.log.load_from_header(self.hdul[0].header)
 
     def load_hdul(self, path_to_file):
         print(f"[Cube] Loading HDUL {path_to_file}")

--- a/src/pykoala/data_container.py
+++ b/src/pykoala/data_container.py
@@ -51,7 +51,7 @@ class LogEntry(object):
         """Convert the entry into a string."""
         comments = "\n".join(self.comments)
         if title:
-            comments += f"{self.title}: "
+            comments = f"{self.title}: " + comments
         return comments
 
 class HistoryLog(object):
@@ -117,7 +117,7 @@ class HistoryLog(object):
                 entry = LogEntry(title=title, comments=comments, tag=tag)
             else:
                 raise NameError(
-                    "Unrecognisez input entry of type {entry.__class__}")
+                    "Unrecognized input entry of type {entry.__class__}")
             self.log_entries.append(entry)
 
     def log_entry(self, title, comments, tag=None):

--- a/src/pykoala/data_container.py
+++ b/src/pykoala/data_container.py
@@ -240,8 +240,8 @@ class HistoryLog(object):
         if self.verbose:
             print("[Log] ", *mssg)
 
-    def __call__(self, title, comments):
-        self.log_entry(title, comments)
+    def __call__(self, *args, **kwargs):
+        self.log_entry(*args, **kwargs)
 
 
 class Parameter(object):
@@ -282,8 +282,6 @@ class DataContainer(object):
         if self.info is None:
             self.info = dict()
         self.log = kwargs.get("log", HistoryLog())
-        if self.log is None:
-            self.log = dict()
         self.fill_info()
 
     def fill_info(self):

--- a/src/pykoala/data_container.py
+++ b/src/pykoala/data_container.py
@@ -3,17 +3,255 @@ This module contains the parent class that represents the data used during the
 reduction process
 """
 
+from astropy.io import Header
 import numpy as np
 
 from pykoala.exceptions.exceptions import NoneAttrError
 
+class LogEntry(object):
+    """Log information unit.
+    
+    Description
+    -----------
+    This class represents a unit of information stored in a log.
+
+    Attributes
+    ----------
+    - title: (str)
+        Title of the entry.
+    - comments: (str)
+        List of strings the information to be stored.
+
+    Methods
+    -------
+    - to_str:
+        Return a string containing the information of 
+        the entry.
+    """
+    def __init__(self, title, comments, tag=None) -> None:
+        self.title = title
+        self.comments = comments
+        self.tag = tag
+    
+    @property
+    def comments(self):
+        return self._comments
+    
+    @comments.setter
+    def comments(self, comments):
+        if isinstance(comments, list):
+            self._comments = comments
+        elif isinstance(comments, str):
+            self._comments = comments.split("\n")
+        else:
+            raise NameError("Input comments must be str or list of strings not:"
+                            + f" {comments.__class__}")
+
+    def to_str(self, title=True):
+        """Convert the entry into a string."""
+        comments = "\n".join(self.comments)
+        if title:
+            comments += f"{self.title}: "
+        return comments
+
+class HistoryLog(object):
+    """Data reduction history logger class.
+    
+    Description
+    -----------
+    This class stores the data reduction history of a DataContainer by creating
+    consecutive log entries.
+
+    Attributes
+    ----------
+    #TODO
+
+    Methods
+    -------
+    #TODO
+    """
+    verbose = True
+    log_entries = None
+    tags = None
+
+    def __init__(self, list_of_entries=None, **kwargs):
+        self.vprint("Initialising history log")
+        self.log_entries = []
+        self.tags = []
+        self.verbose = kwargs.get('verbose', True)
+
+        if list_of_entries is not None:
+            self.initialise_log(list_of_entries)
+    
+    def initialise_log(self, list_of_entries):
+        """Initialise the log from a set of input entries.
+        
+        Description
+        -----------
+        This method initialises the log using a collection of entries. The
+        input can be in the form of a, interable consisting of LogEntry objects
+        or an interable containing a 2 or 3 elements iterable (title, comments)
+        or (title, comments, tag).
+
+        Parameters
+        ----------
+        - list_of_entries: (iterable)
+            Set of entries to be recorded in the log.
+
+        Returns
+        -------
+        """
+        for entry in list_of_entries:
+            if isinstance(entry, LogEntry):
+                self.log_entries.append(entry)
+            elif isinstance(entry, tuple) or isinstance(entry, list):
+                if len(entry) == 2:
+                    title, comments = entry
+                    tag = None
+                elif len(entry) == 3:
+                    title, comments, tag = entry
+                else:
+                    raise NameError(
+                        "Input entry must contain two (title, comments) or"
+                        + " three (title, comments, tag) elements")
+                entry = LogEntry(title=title, comments=comments, tag=tag)
+            else:
+                raise NameError(
+                    "Unrecognisez input entry of type {entry.__class__}")
+            self.log_entries.append(entry)
+
+    def log_entry(self, title, comments, tag=None):
+        """Include a new entry in the log.
+        
+        Parameters
+        ----------
+        - title: (str)
+            Title of the entry.
+        - comments: (list or str, default=None)
+            List containing the comments of this entry. Lines will be splited
+            into different elements of the log.
+        """
+        self.vprint(f"Logging entry > {title}:{comments}")
+        if tag is not None and tag not in self.tags:
+            self.tags.append(tag)
+        entry = LogEntry(title=title, comments=comments, tag=tag)
+        self.log_entries.append(entry)
+
+    def is_entry(self, title, comment=None):
+        """Find an entry that contains the input information.
+        
+        Parameters
+        -----------
+        - title: (str)
+            Title of the entry.
+        - comment: (str, default=None)
+            If provided, the match will require the entry to contain the input
+            comment.
+
+        Returns
+        -------
+        - found: (bool)
+            `True` if the entry is found, `False` otherwise.
+        """
+        for entry in self.log_entries:
+            if entry.title == title:
+                if comment is not None:
+                    if comment in entry.comments:
+                        return True
+                else:
+                    return True
+        return False
+    
+    def get_tag(self, tag):
+        """Return all entries matching a given tag.
+        
+        Parameters
+        ----------
+        - tag: (str)
+            Input tag used for the search
+
+        Returns
+        -------
+        - entries: (list)
+            List of entries associated to the input tag.
+        """
+        return [entry for entry in self.log_entries if entry.tag == tag]
+
+    def dump_to_header(self, header=None):
+        """Write the log into a astropy.fits.Header.
+        
+        Description
+        -----------
+        Save the entries of the log in a Header. All entries will be saved using
+        card names `PYKOALAnumber`, where number corresponds to an index ranging
+        from 0 to the number of entries contained in the log.
+
+        Parameters
+        ----------
+
+        """
+        if header is None:
+            header = Header()
+            index = 0
+        else:
+            index = len(self.get_entries_from_header(header))
+
+        for entry in self.log_entries:
+            header['PYKOALA' + index] = (
+                entry.comments.to_str(title=False), entry.title)
+        return header
+
+    def dump_to_text(self, file):
+        """Write the log into a text file
+        
+        Parameters
+        ----------
+        - file: (str)
+            Output file name.
+        
+        Returns
+        -------
+        """
+        self.vprint("Writting log into text file")
+        with open(file, "w") as f:
+            for entry in self.log_entries:
+                f.write(
+                    entry.to_str() + "\n")
+
+    def get_entries_from_header(self, header):
+        """Get entries created by PyKOALA from an input FITS Header."""
+        return map(LogEntry, zip(header.comments['PYKOALA*'],
+                                 header['PYKOALA*']))
+
+    def load_from_header(self, header):
+        """Load the Log from a FITS Header."""
+        list_of_entries = self.get_entries_from_header(header)
+        self.log_entries = list(list_of_entries)
+
+    def show(self):
+        for entry in self.log_entries:
+            print(entry.to_str())
+
+    def vprint(self, *mssg):
+        if self.verbose:
+            print("[Log] ", *mssg)
+
+    def __call__(self, title, comments):
+        self.log_entry(title, comments)
+
+
+class Parameter(object):
+    """Class that represents some parameter and associated metadata"""
+    def __init__(self) -> None:
+        pass
+    
 
 class DataContainer(object):
     """
     Abstract class for data containers.
 
-    This class might represent any kind of astronomical data: raw fits files, Row Stacked Spectra
-    obtained after tramline extraction or datacubes.
+    This class might represent any kind of astronomical data: raw fits files,
+    Row Stacked Spectra obtained after tramline extraction or datacubes.
 
     Attributes
     ----------
@@ -39,7 +277,7 @@ class DataContainer(object):
         self.info = kwargs.get("info", dict())
         if self.info is None:
             self.info = dict()
-        self.log = kwargs.get("log", dict(corrections=dict()))
+        self.log = kwargs.get("log", dict())
         if self.log is None:
             self.log = dict()
         self.fill_info()

--- a/src/pykoala/instruments/koala_ifu.py
+++ b/src/pykoala/instruments/koala_ifu.py
@@ -17,6 +17,7 @@ from astropy.wcs import WCS
 # KOALA packages
 # =============================================================================
 from pykoala.ancillary import vprint, rss_info_template  # Template to create the info variable 
+from pykoala.data_container import HistoryLog
 from pykoala.rss import RSS
 
 def airmass_from_header(header):
@@ -124,13 +125,7 @@ def read_rss(file_path,
     """TODO."""
     # Blank dictionary for the log
     if log is None:
-        log = {'read': {'comment': None, 'index': None},
-               'mask from file': {'comment': None, 'index': 0},
-               'blue edge': {'comment': None, 'index': 1},
-               'red edge': {'comment': None, 'index': 2},
-               'cosmic': {'comment': None, 'index': 3},
-               'extreme negative': {'comment': None, 'index': 4},
-               'wavelength fix': {'comment': None, 'index': None, 'sol': []}}
+        log = HistoryLog()
     if header is None:
         # Blank Astropy Header object for the RSS header
         # Example how to add header value at the end
@@ -144,6 +139,7 @@ def read_rss(file_path,
 
     #  Open fits file. This assumes that RSS objects are written to file as .fits.
     with fits.open(file_path) as rss_fits:
+        log('read', ' '.join(['- RSS read from ', file_name]))
         # Read intensity using rss_fits_file[0]
         all_intensities = np.array(rss_fits[intensity_axis].data, dtype=np.float32)
         intensity = np.delete(all_intensities, bad_fibres_list, 0)
@@ -168,9 +164,6 @@ def read_rss(file_path,
     nrow, ncol = wcs.array_shape
     wavelength_index = np.arange(ncol)
     wavelength = wcs.dropaxis(1).wcs_pix2world(wavelength_index, 0)[0]
-    # log
-    comment = ' '.join(['- RSS read from ', file_name])
-    log['read']['comment'] = comment
     # First Header value added by the PyKoala routine
     header.append(('DARKCORR', 'OMIT', 'Dark Image Subtraction'), end=True)
 

--- a/src/pykoala/instruments/weave.py
+++ b/src/pykoala/instruments/weave.py
@@ -18,6 +18,7 @@ from astropy import units as u
 # KOALA packages
 # =============================================================================
 from pykoala.rss import RSS
+from pykoala.data_container import HistoryLog
 
 def weave_rss(filename):
     '''Read a WEAVE "single exposure" file (i.e. row-stacked spectra for just one arm)'''
@@ -31,15 +32,7 @@ def weave_rss(filename):
         variance = np.where(hdu[4].data > 0, 1/hdu[4].data, np.nan)
         fibtable = Table.read(hdu['FIBTABLE'])
 
-    # This is ugly :^(
-    log = {'read': {'comment': None, 'index': None},
-           'mask from file': {'comment': None, 'index': 0},
-           'blue edge': {'comment': None, 'index': 1},
-           'red edge': {'comment': None, 'index': 2},
-           'cosmic': {'comment': None, 'index': 3},
-           'extreme negative': {'comment': None, 'index': 4},
-           'wavelength fix': {'comment': None, 'index': None, 'sol': []}}
-    
+    log = HistoryLog()
     info = {}
 
     print(f'Targets in {filename}:')

--- a/src/pykoala/rss.py
+++ b/src/pykoala/rss.py
@@ -119,7 +119,7 @@ class RSS(DataContainer):
                                                              self.info["fib_dec"].copy())
         self.info["fib_ra"] = new_fib_coord[0]
         self.info["fib_dec"] = new_fib_coord[1]
-        self.log['update_coords'] = "Offset-coords updated"
+        self.log('update_coords', "Offset-coords updated")
         print("[RSS] Offset-coords updated")
 
     # =============================================================================


### PR DESCRIPTION
This PR includes a new class for dealing with the DR log history: `HistoryLog`. In summary, it basically consists of a set of entries (`LogEntry`) that contain a title, a collection of comments and a tag. The class can write/load the log into/from a header, as well as text files, among other fancy features.

The implementation of this class throughout the rest of the pipeline is currently on hold until we decide whether or not this is the best approach to deal with the reduction history.

Please, have a look at the new code and let me know if you are happy with me including it on the rest of the modules.